### PR TITLE
Allow stopping scan with ctrl + C 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,12 +55,15 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.4.3"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
 dependencies = [
+ "async-channel",
  "async-executor",
  "async-io",
+ "async-mutex",
+ "blocking",
  "futures-lite",
  "num_cpus",
  "once_cell",
@@ -87,10 +90,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-mutex"
-version = "1.3.0"
+name = "async-lock"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66941c2577c4fa351e4ce5fdde8f86c69b88d623f3b955be1bc7362a23434632"
+checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
 ]
@@ -113,17 +125,16 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
+checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
 dependencies = [
  "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "async-process",
- "blocking",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -285,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fastrand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "once_cell",
- "signal-hook",
+ "signal-hook 0.1.17",
  "winapi",
 ]
 
@@ -490,6 +490,8 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "signal-hook 0.3.2",
+ "signal-hook-async-std",
 ]
 
 [[package]]
@@ -570,6 +572,27 @@ checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f12c113f6545af584585f757a384ce4e88e9c935c45ee05e3f09f48a7ce4195"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-async-std"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f200d91f8fdd484445887f1034032f4953918bb71f55b45f561b18419239c3"
+dependencies = [
+ "async-std",
+ "libc",
+ "signal-hook 0.3.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,6 @@ cidr= {version = "0.1", default-features=false}
 async-std = { version = "1.8", features=["attributes", "unstable"]}
 serde_json = {version = "1.0"}
 serde = { version="1.0", features = ["derive"]}
+signal-hook-async-std = { version="0.2"}
+signal-hook = {version="0.3"}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ clap="2.33.0"
 log="0.4"
 env_logger="0.7.1"
 cidr= {version = "0.1", default-features=false}
-async-std = { version = "1.8", features=["attributes", "unstable"]}
+async-std = { version = "1.9", features=["attributes", "unstable"]}
 serde_json = {version = "1.0"}
 serde = { version="1.0", features = ["derive"]}
 signal-hook-async-std = { version="0.2"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ async fn main() {
         .arg(
             clap::Arg::with_name("timeout")
                 .long("timeout")
-                .short("t")
+                .short("T")
                 .takes_value(true)
                 .default_value("1000")
                 .required(false)

--- a/src/output.rs
+++ b/src/output.rs
@@ -83,8 +83,8 @@ impl HostInfo {
 
     pub fn get_delays(&self) -> (Duration, Duration) {
         (
-            self.min_delay.unwrap_or(Duration::from_secs(0)),
-            self.max_delay.unwrap_or(Duration::from_secs(0)),
+            self.min_delay.unwrap_or_else(|| Duration::from_secs(0)),
+            self.max_delay.unwrap_or_else(|| Duration::from_secs(0)),
         )
     }
 }


### PR DESCRIPTION
 * Ongoing scan can be properly stopped by pressing ctrl+c
 * Minor clip warning fixes and removal of duplicate command line parameter
 * Update to async-std 1.9